### PR TITLE
Update plugin versions in Gradle configuration

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ junit = "4.13.2"
 
 # plugins
 changelog = "2.2.1"
-intelliJPlatform = "2.2.1"
+intelliJPlatform = "2.5.0"
 kotlin = "2.1.20"
 kover = "0.9.1"
 qodana = "2024.3.4"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
 }
 
 rootProject.name = "load-env-file-plugin"


### PR DESCRIPTION
Upgraded Foojay resolver to 0.10.0 and IntelliJ Platform to 2.5.0. These updates ensure compatibility with the latest features and improvements. No other changes were made.