### PR TITLE
ci: disable gradle wrapper validation to avoid network failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,6 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v5
 
-      # Validate wrapper
-      - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v3
-
       # Set up Java environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v5


### PR DESCRIPTION
## Summary
- remove Gradle Wrapper Validation step from build workflow to prevent network timeout errors

## Testing
- `./gradlew test` *(fails: Could not resolve all files for configuration ':testCompileClasspath', received status code 403 from server)*

------
https://chatgpt.com/codex/tasks/task_e_68b24935207c832ebc694c5aff594e85