### PR TITLE
refactor run configuration env setters

### DIFF
--- a/src/main/kotlin/jp/kroyeeg/intellijenvfileplugin/run/ExternalSystemRunConfigurationEnvSetter.kt
+++ b/src/main/kotlin/jp/kroyeeg/intellijenvfileplugin/run/ExternalSystemRunConfigurationEnvSetter.kt
@@ -1,0 +1,15 @@
+package jp.kroyeeg.intellijenvfileplugin.run
+
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.openapi.externalSystem.service.execution.ExternalSystemRunConfiguration
+
+/**
+ * Applies environment variables to [ExternalSystemRunConfiguration] instances.
+ */
+class ExternalSystemRunConfigurationEnvSetter : RunConfigurationEnvSetter {
+    override fun setEnvironment(configuration: RunConfiguration, env: Map<String, String>) {
+        val config = configuration as ExternalSystemRunConfiguration
+        val settings = config.settings
+        settings.env = settings.env + env
+    }
+}

--- a/src/main/kotlin/jp/kroyeeg/intellijenvfileplugin/run/ModuleBasedRunConfigurationEnvSetter.kt
+++ b/src/main/kotlin/jp/kroyeeg/intellijenvfileplugin/run/ModuleBasedRunConfigurationEnvSetter.kt
@@ -1,0 +1,28 @@
+package jp.kroyeeg.intellijenvfileplugin.run
+
+import com.intellij.execution.configurations.ModuleBasedConfiguration
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.openapi.diagnostic.thisLogger
+
+/**
+ * Applies environment variables to [ModuleBasedConfiguration] instances via reflection.
+ */
+class ModuleBasedRunConfigurationEnvSetter : RunConfigurationEnvSetter {
+    override fun setEnvironment(configuration: RunConfiguration, env: Map<String, String>) {
+        val config = configuration as ModuleBasedConfiguration<*, *>
+        runCatching {
+            val methods = config.state!!.javaClass.methods
+            val getEnvMethod = methods.find { it.name == "getEnv" }
+            val setEnvMethod = methods.find { it.name == "setEnv" }
+            val newEnv = getEnvMethod?.let { method ->
+                method.isAccessible = true
+                val envs = method.invoke(config.state) as Map<*, *>
+                envs + env
+            }
+            setEnvMethod?.let { method ->
+                method.isAccessible = true
+                method.invoke(config.state, newEnv)
+            }
+        }.onFailure { thisLogger().error(it) }
+    }
+}

--- a/src/main/kotlin/jp/kroyeeg/intellijenvfileplugin/run/RunConfigurationEnvSetter.kt
+++ b/src/main/kotlin/jp/kroyeeg/intellijenvfileplugin/run/RunConfigurationEnvSetter.kt
@@ -1,0 +1,13 @@
+package jp.kroyeeg.intellijenvfileplugin.run
+
+import com.intellij.execution.configurations.RunConfiguration
+
+/**
+ * Sets environment variables on a specific [RunConfiguration] implementation.
+ */
+interface RunConfigurationEnvSetter {
+    /**
+     * Applies the provided [env] variables to the given [configuration].
+     */
+    fun setEnvironment(configuration: RunConfiguration, env: Map<String, String>)
+}


### PR DESCRIPTION
## Summary
- map run configuration types to env setter classes and instantiate only when needed
- remove `isApplicable` from `RunConfigurationEnvSetter`
- update listener and setters accordingly

## Testing
- `./gradlew test` *(fails: Could not resolve all files for configuration ':testCompileClasspath')*

------
https://chatgpt.com/codex/tasks/task_e_68b25462369c832e82a418975982082c