### PR TITLE
Add Shell Script (Bash) run configuration support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ platformVersion = 2025.2
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP
 platformPlugins =
 # Example: platformBundledPlugins = com.intellij.java
-platformBundledPlugins =
+platformBundledPlugins = com.intellij.sh
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 9.2.1

--- a/src/main/kotlin/jp/kroyeeg/intellijenvfileplugin/run/EnvRunConfigurationListener.kt
+++ b/src/main/kotlin/jp/kroyeeg/intellijenvfileplugin/run/EnvRunConfigurationListener.kt
@@ -6,6 +6,7 @@ import com.intellij.execution.RunnerAndConfigurationSettings
 import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.execution.configurations.ModuleBasedConfiguration
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemRunConfiguration
+import com.intellij.sh.run.ShRunConfiguration
 
 /**
  * Listens for run configuration changes and delegates environment variable application
@@ -16,6 +17,7 @@ class EnvRunConfigurationListener : RunManagerListener {
     private val setterMapping: Map<Class<out RunConfiguration>, Class<out RunConfigurationEnvSetter>> = mapOf(
         ExternalSystemRunConfiguration::class.java to ExternalSystemRunConfigurationEnvSetter::class.java,
         ModuleBasedConfiguration::class.java to ModuleBasedRunConfigurationEnvSetter::class.java,
+        ShRunConfiguration::class.java to ShRunConfigurationEnvSetter::class.java,
     )
 
     override fun runConfigurationAdded(settings: RunnerAndConfigurationSettings) {

--- a/src/main/kotlin/jp/kroyeeg/intellijenvfileplugin/run/ShRunConfigurationEnvSetter.kt
+++ b/src/main/kotlin/jp/kroyeeg/intellijenvfileplugin/run/ShRunConfigurationEnvSetter.kt
@@ -1,0 +1,14 @@
+package jp.kroyeeg.intellijenvfileplugin.run
+
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.sh.run.ShRunConfiguration
+
+/**
+ * Applies environment variables to [ShRunConfiguration] instances (Shell Script).
+ */
+class ShRunConfigurationEnvSetter : RunConfigurationEnvSetter {
+    override fun setEnvironment(configuration: RunConfiguration, env: Map<String, String>) {
+        val config = configuration as ShRunConfiguration
+        config.envData = config.envData.with(config.envData.envs + env)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,7 @@
     <vendor>sh-ogawa</vendor>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends>com.intellij.sh</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <projectConfigurable id="jp.kroyeeg.intellijenvfileplugin.settings"

--- a/src/test/kotlin/jp/kroyeeg/intellijenvfileplugin/LoadEnvFilePluginTest.kt
+++ b/src/test/kotlin/jp/kroyeeg/intellijenvfileplugin/LoadEnvFilePluginTest.kt
@@ -4,6 +4,7 @@ import com.intellij.testFramework.TestDataPath
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import jp.kroyeeg.intellijenvfileplugin.services.EnvFileService
 import jp.kroyeeg.intellijenvfileplugin.run.EnvRunConfigurationListener
+import jp.kroyeeg.intellijenvfileplugin.run.ShRunConfigurationEnvSetter
 import java.io.File
 
 @TestDataPath("\$CONTENT_ROOT/src/test/testData")
@@ -90,7 +91,20 @@ class LoadEnvFilePluginTest : BasePlatformTestCase() {
         assertEquals("foo", result["B"]) // expands from A
         assertEquals("foo", result["C"]) // expands transitively
         // cycle should not infinite-loop and should leave at least one unresolved placeholder
-        assertEquals("${'$'}{E}", result["D"]) 
-        assertEquals("${'$'}{D}", result["E"]) 
+        assertEquals("${'$'}{E}", result["D"])
+        assertEquals("${'$'}{D}", result["E"])
+    }
+
+    fun testShRunConfigurationMappingRegistered() {
+        val listener = EnvRunConfigurationListener()
+        val field = EnvRunConfigurationListener::class.java.getDeclaredField("setterMapping")
+        field.isAccessible = true
+
+        @Suppress("UNCHECKED_CAST")
+        val mapping = field.get(listener) as Map<Class<*>, Class<*>>
+
+        val shConfigClass = Class.forName("com.intellij.sh.run.ShRunConfiguration")
+        assertTrue("ShRunConfiguration should be in setter mapping", mapping.containsKey(shConfigClass))
+        assertEquals(ShRunConfigurationEnvSetter::class.java, mapping[shConfigClass])
     }
 }


### PR DESCRIPTION
Add ShRunConfigurationEnvSetter to inject .env variables into Shell Script
run configurations via ShRunConfiguration's envData API. Register the
com.intellij.sh bundled plugin as a dependency.

https://claude.ai/code/session_01NuWtsKq68t3M3vUYgF31fx